### PR TITLE
Update http-parser to 2.6.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/src/http-parser"]
-	path = deps/src/http-parser
-	url = https://github.com/joyent/http-parser.git

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HttpParser.jl
 
-This package provides a Julia wrapper around Joyent's [http-parser](https://github.com/joyent/http-parser) library (v2.1).
+This package provides a Julia wrapper around Joyent's [http-parser](https://github.com/joyent/http-parser) library (v2.6.0).
 
 [![Build Status](https://travis-ci.org/JuliaWeb/HttpParser.jl.svg?branch=master)](https://travis-ci.org/JuliaWeb/HttpParser.jl)
 [![Coverage Status](https://coveralls.io/repos/JuliaWeb/HttpParser.jl/badge.svg?branch=master)](https://coveralls.io/r/JuliaWeb/HttpParser.jl?branch=master)
@@ -16,9 +16,10 @@ This package provides a Julia wrapper around Joyent's [http-parser](https://gith
 
 1. `git clone https://github.com/joyent/http-parser`
 2. `cd http-parser`
-3. `git checkout v2.1`
-4. `make library # Outputs a .so file, should be a .dylib on OS X`
-5. move the `libhttp_parser.so` to `/usr/local/lib` (rename to `libhttp_parser.dylib` if on OS X)
+2. `git checkout v2.6.0`
+3. `make library # Outputs a .so file, should be a .dylib on OS X`
+4. move the `libhttp_parser.so` to `/usr/local/lib` (rename to `libhttp_parser.dylib` if on OS X)
+
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HttpParser.jl
 
-This package provides a Julia wrapper around Joyent's [http-parser](https://github.com/joyent/http-parser) library (v2.6.0).
+This package provides a Julia wrapper around Joyent's [http-parser](https://github.com/joyent/http-parser) library (v2.6.2).
 
 [![Build Status](https://travis-ci.org/JuliaWeb/HttpParser.jl.svg?branch=master)](https://travis-ci.org/JuliaWeb/HttpParser.jl)
 [![Coverage Status](https://coveralls.io/repos/JuliaWeb/HttpParser.jl/badge.svg?branch=master)](https://coveralls.io/r/JuliaWeb/HttpParser.jl?branch=master)
@@ -10,22 +10,7 @@ This package provides a Julia wrapper around Joyent's [http-parser](https://gith
 
 **Installation**: `julia> Pkg.add("HttpParser")`
 
-`libhttp-parser` needs to be available as a shared library, but it will be built automatically on Linux and OSX, and downloaded as a binary on Windows.
-
-### Installing libhttp-parser as a shared library manually
-
-1. `git clone https://github.com/joyent/http-parser`
-2. `cd http-parser`
-2. `git checkout v2.6.0`
-3. `make library # Outputs a .so file, should be a .dylib on OS X`
-4. move the `libhttp_parser.so` to `/usr/local/lib` (rename to `libhttp_parser.dylib` if on OS X)
-
-
-## Test
-
-5. `cd` back to `.julia/v0.3/HttpParser/`
-6. `julia test/runtests.jl`
-7. Expect to see text indicating that all assertions have passed.
+`libhttp-parser` shared library will be built automatically on Linux and OSX, and downloaded as a binary on Windows.
 
 ## Building the Windows binaries
 
@@ -33,9 +18,9 @@ The current `http-parser` binary for Windows is cross-compiled using `mingw-w64`
 `mingw-w64` can be installed on Ubuntu using `sudo apt-get install mingw-w64`.
 To build for yourself:
  * `git clone https://github.com/joyent/http-parser`
- * `git checkout 80819384450b5511a3d1c424dd92a5843c891364` (or whatever SHA the submodule in `HttpParser.jl/deps/src/` currently points to)
- * There are currently warnings that are treated as errors. Edit the Makefile to
-   remove -Werror
+ * `cd http-parser`
+ * `git checkout v2.6.2`
+ * There are currently warnings that are treated as errors. Edit the Makefile to remove -Werror
  * To build 64-bit DLL: `CC=x86_64-w64-mingw32-gcc make library && mv libhttp_parser.so libhttp_parser64.dll`
  * To build 32-bit DLL: `CC=i686-w64-mingw32-gcc make library && mv libhttp_parser.so libhttp_parser32.dll`
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,20 +14,16 @@ end
 libhttp_parser = library_dependency("libhttp_parser", aliases=aliases)
 
 @unix_only begin
-    depsdir = joinpath(Pkg.dir(),"HttpParser","deps")
-    prefix=joinpath(depsdir,"usr")
-    uprefix = replace(replace(prefix,"\\","/"),"C:/","/c/")
-    target = joinpath(prefix,"lib/libhttp_parser.$(BinDeps.shlib_ext)")
+    prefix = BinDeps.usrdir(libhttp_parser)
+    target = joinpath(prefix,"lib","libhttp_parser.$(BinDeps.shlib_ext)")
 
     provides(SimpleBuild,
         (@build_steps begin
-            ChangeDirectory(Pkg.Dir.path("HttpParser"))
+            ChangeDirectory(BinDeps.pkgdir(libhttp_parser))
             FileRule("deps/src/http-parser/Makefile",`git submodule update --init`)
-            FileRule(target,@build_steps begin
-                ChangeDirectory(Pkg.Dir.path("HttpParser","deps","src"))
-                CreateDirectory(dirname(target))
-                MakeTargets(["-C","http-parser","library"])
-                `cp http-parser/libhttp_parser.so $target`
+            FileRule(target, @build_steps begin
+                ChangeDirectory(BinDeps.srcdir(libhttp_parser))
+                MakeTargets(["-C","http-parser","install"], env=Dict("PREFIX"=>prefix))
             end)
         end),[libhttp_parser], os = :Unix)
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,15 +15,18 @@ libhttp_parser = library_dependency("libhttp_parser", aliases=aliases)
 
 @unix_only begin
     prefix = BinDeps.usrdir(libhttp_parser)
-    target = joinpath(prefix,"lib","libhttp_parser.$(BinDeps.shlib_ext)")
+    target = "libhttp_parser.$(BinDeps.shlib_ext)"
+    targetpath = joinpath(BinDeps.libdir(libhttp_parser),target)
 
     provides(SimpleBuild,
         (@build_steps begin
             ChangeDirectory(BinDeps.pkgdir(libhttp_parser))
             FileRule("deps/src/http-parser/Makefile",`git submodule update --init`)
-            FileRule(target, @build_steps begin
+            FileRule(targetpath, @build_steps begin
                 ChangeDirectory(BinDeps.srcdir(libhttp_parser))
-                MakeTargets(["-C","http-parser","install"], env=Dict("PREFIX"=>prefix))
+                CreateDirectory(dirname(targetpath))
+                MakeTargets(["-C","http-parser","library"], env=Dict("SONAME"=>target))
+                `cp http-parser/$target $targetpath`
             end)
         end),[libhttp_parser], os = :Unix)
 end

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -79,7 +79,8 @@ type ParserSettings
 end
 
 function show(io::IO,p::Parser)
-    print(io,"HttpParser")
+    print(io,"HTTP/$(p.http_major).$(p.http_minor), ")
+    print(io,"Content-Length: $(p.content_length)")
 end
 
 # Intializes the Parser object with the correct memory.
@@ -90,8 +91,8 @@ end
 # Run a request through a parser with specific callbacks on the settings instance.
 function http_parser_execute(parser::Parser, settings::ParserSettings, request)
     ccall((:http_parser_execute, lib), Csize_t,
-            (Ptr{Parser}, Ptr{ParserSettings}, Ptr{UInt8}, Csize_t,),
-            &parser, &settings, convert(Ptr{UInt8}, pointer(request)), sizeof(request))
+           (Ptr{Parser}, Ptr{ParserSettings}, Cstring, Csize_t,),
+            Ref(parser), Ref(settings), convert(Cstring, pointer(request)), sizeof(request))
     if errno(parser) != 0
         throw(HttpParserError(errno(parser)))
     end

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -173,7 +173,7 @@ immutable ParserUrl
     field_set::UInt16 # Bitmask of (1 << UF_*) values
     port::UInt16      # Converted UF_PORT string
     field_data::NTuple{UF_MAX.val*2, UInt16}
-    ParserUrl() = new(zero(UInt16), zero(UInt16), ntuple(UF_MAX.val*2, i->zero(UInt16)))
+    ParserUrl() = new(zero(UInt16), zero(UInt16), ntuple(i->zero(UInt16), UF_MAX.val*2))
 end
 
 "Parse a URL"
@@ -186,7 +186,7 @@ function parse_url(url::AbstractString; isconnect::Bool = false)
     res > 0 && return parsed, -1
     purl = purl_ref[]
 
-    for (i,uf) in enumerate(UrlFields)
+    for (i,uf) in enumerate(instances(UrlFields))
         !((purl.field_set & (1 << uf.val) > 0) && uf != UF_MAX) && continue
         off = purl.field_data[2*(i-1)+1]
         len = purl.field_data[2*(i-1)+2]

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -68,8 +68,8 @@ Parser() = Parser(
 )
 
 # Datatype Tuples for the different `cfunction` signatures for callback functions
-HTTP_CB      = (Int, (Ptr{Parser},))
-HTTP_DATA_CB = (Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
+const HTTP_CB      = (Int, (Ptr{Parser},))
+const HTTP_DATA_CB = (Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
 
 # A composite type that is expecting C functions to be run as callbacks.
 type ParserSettings

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -126,9 +126,9 @@ function http_should_keep_alive(parser::Ptr{Parser})
 end
 
 "Pauses the parser."
-pause(parser::Parser) = ccall((:http_parser_pause,lib), Void, (Ptr{Parser}, Cint), Ref(parser), zero(Cint))
+pause(parser::Parser) = ccall((:http_parser_pause,lib), Void, (Ptr{Parser}, Cint), Ref(parser), one(Cint))
 "Resumes the parser."
-resume(parser::Parser) = ccall((:http_parser_pause,lib), Void,(Ptr{Parser}, Cint), Ref(parser), one(Cint))
+resume(parser::Parser) = ccall((:http_parser_pause,lib), Void,(Ptr{Parser}, Cint), Ref(parser), zero(Cint))
 "Checks if this is the final chunk of the body."
 isfinalchunk(parser::Parser) = ccall((:http_parser_pause,lib), Cint, (Ptr{Parser},), Ref(parser)) == 1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,4 +209,18 @@ typealias ParsedUrl Dict{Symbol, AbstractString}
     :UF_SCHEMA=>"http"
 ), 8000)
 
+@test HttpParser.version() >= v"2.6"
+
+p = Parser()
+HttpParser.pause(p)
+err = HttpParser.errno(p)
+@test err == 0x1f
+@test HttpParser.errno_name(err) == "HPE_PAUSED"
+@test HttpParser.errno_description(err) == "parser is paused"
+HttpParser.resume(p)
+@test HttpParser.errno(p) == 0x00
+
+ex = HttpParser.HttpParserError(0x1f)
+@test ex.errno == 0x1f
+
 info("All assertions passed!")


### PR DESCRIPTION
This is update of `http-parser` version to 2.5.0 for Julia 0.4 only.