### PR TITLE
remove deprecation warning emitting `int32`

### DIFF
--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -7,6 +7,7 @@ module HttpParser
 
 include("../deps/deps.jl")
 
+using Compat
 using HttpCommon
 
 import Base.show
@@ -114,7 +115,7 @@ errno_description(errno::Integer) = bytestring(ccall((:http_errno_description,li
 
 immutable HttpParserError <: Exception
     errno::Int32
-    HttpParserError(errno::Integer) = new(int32(errno))
+    HttpParserError(errno::Integer) = new(@compat Int32(errno))
 end
 
 show(io::IO, err::HttpParserError) = print(io,"HTTP Parser Exception: ",errno_name(err.errno),"(",string(err.errno),"):",errno_description(err.errno))


### PR DESCRIPTION
@hayd cleared most of the deprecation warnings in #33. But, there was a rouge `int32` in the `HttpParserError` constructor. `runtests.jl` doesn't run that code, so it's easy to miss.