### PR TITLE
Closes #39

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.4-
 HttpCommon
 BinDeps
-Compat

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,4 @@
 using BinDeps
-using Compat
 
 @BinDeps.setup
 
@@ -40,5 +39,5 @@ end
          libhttp_parser, os = :Windows)
 end
 
-@BinDeps.install @compat Dict(:libhttp_parser => :lib)
+@BinDeps.install Dict(:libhttp_parser => :lib)
 

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -114,7 +114,7 @@ errno_description(errno::Integer) = bytestring(ccall((:http_errno_description,li
 
 immutable HttpParserError <: Exception
     errno::Int32
-    HttpParserError(errno::Integer) = new(int32(errno))
+    HttpParserError(errno::Integer) = new(Int32(errno))
 end
 
 show(io::IO, err::HttpParserError) = print(io,"HTTP Parser Exception: ",errno_name(err.errno),"(",string(err.errno),"):",errno_description(err.errno))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using HttpParser
 using HttpCommon
 using Base.Test
-using Compat
 
 FIREFOX_REQ = tuple("GET /favicon.ico HTTP/1.1\r\n",
          "Host: 0.0.0.0=5000\r\n",
@@ -46,7 +45,7 @@ end
 
 function on_url(parser, at, len)
     # Concatenate the resource for each on_url callback
-    r.resource = string(r.resource, bytestring(convert(Ptr{Uint8}, at), @compat Int(len)))
+    r.resource = string(r.resource, bytestring(convert(Ptr{Uint8}, at), Int(len)))
     return 0
 end
 
@@ -55,14 +54,14 @@ function on_status_complete(parser)
 end
 
 function on_header_field(parser, at, len)
-    header = bytestring(convert(Ptr{Uint8}, at), @compat Int(len))
+    header = bytestring(convert(Ptr{Uint8}, at), Int(len))
     # set the current header
     r.headers["current_header"] = header
     return 0
 end
 
 function on_header_value(parser, at, len)
-    s = bytestring(convert(Ptr{Uint8}, at), @compat Int(len))
+    s = bytestring(convert(Ptr{Uint8}, at), Int(len))
     # once we know we have the header value, that will be the value for current header
     r.headers[r.headers["current_header"]] = s
     # reset current_header


### PR DESCRIPTION
Prior commits cleared 0.4 deprecation warnings. This commit clears
the last one remaining. It also removes the `Compat` requirement,
since 0.3 is not supported.