### PR TITLE
use different name for a build-in dependency library in build script

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -13,44 +13,44 @@ aliases = []
     end
 end
 
-libhttp_parser = library_dependency("libhttp_parser", aliases=aliases)
+libhttp_parser_jl = library_dependency("libhttp_parser_jl", aliases=aliases)
 
 @unix_only begin
     src_arch = "v$version.zip"
     src_url = "https://github.com/nodejs/http-parser/archive/$src_arch"
     src_dir = "http-parser-$version"
 
-    target = "libhttp_parser.$(BinDeps.shlib_ext)"
-    targetdwlfile = joinpath(BinDeps.downloadsdir(libhttp_parser),src_arch)
-    targetsrcdir = joinpath(BinDeps.srcdir(libhttp_parser),src_dir)
-    targetlib    = joinpath(BinDeps.libdir(libhttp_parser),target)
+    target = "libhttp_parser_jl.$(BinDeps.shlib_ext)"
+    targetdwlfile = joinpath(BinDeps.downloadsdir(libhttp_parser_jl),src_arch)
+    targetsrcdir = joinpath(BinDeps.srcdir(libhttp_parser_jl),src_dir)
+    targetlib    = joinpath(BinDeps.libdir(libhttp_parser_jl),target)
 
     provides(SimpleBuild,
         (@build_steps begin
-            CreateDirectory(BinDeps.downloadsdir(libhttp_parser))
+            CreateDirectory(BinDeps.downloadsdir(libhttp_parser_jl))
             FileDownloader(src_url, targetdwlfile)
-            FileUnpacker(targetdwlfile,BinDeps.srcdir(libhttp_parser),targetsrcdir)
+            FileUnpacker(targetdwlfile,BinDeps.srcdir(libhttp_parser_jl),targetsrcdir)
             @build_steps begin
-                CreateDirectory(BinDeps.libdir(libhttp_parser))
+                CreateDirectory(BinDeps.libdir(libhttp_parser_jl))
                 @build_steps begin
                     ChangeDirectory(targetsrcdir)
                     FileRule(targetlib, @build_steps begin
-                        ChangeDirectory(BinDeps.srcdir(libhttp_parser))
+                        ChangeDirectory(BinDeps.srcdir(libhttp_parser_jl))
                         CreateDirectory(dirname(targetlib))
                         MakeTargets(["-C",src_dir,"library"], env=Dict("SONAME"=>target))
                         `cp $src_dir/$target $targetlib`
                     end)
                 end
             end
-        end), libhttp_parser, os = :Unix)
+        end), libhttp_parser_jl, os = :Unix)
 end
 
 # Windows
 @windows_only begin
     provides(Binaries,
          URI("https://julialang.s3.amazonaws.com/bin/winnt/extras/libhttp_parser.zip"),
-         libhttp_parser, os = :Windows)
+         libhttp_parser_jl, os = :Windows)
 end
 
-@BinDeps.install Dict(:libhttp_parser => :lib)
+@BinDeps.install Dict(:libhttp_parser_jl => :lib)
 


### PR DESCRIPTION
Use different name for a build-in dependency library in the build script to avoid hooking to system library [#46].

P.S. Ahh, fine BinDeps hacking.
