### PR TITLE
Added additional constructor to ParserSettings that complies with the old api

### DIFF
--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -87,6 +87,14 @@ type ParserSettings
     on_chunk_complete::Ptr{Void}
 end
 
+function dummy(parser)
+  0
+end
+
+function dummy_data(parser, at, len)
+  0
+end
+
 function ParserSettings(on_message_begin_cb::Ptr{Void},
   on_url_cb::Ptr{Void},
   on_status_complete_cb::Ptr{Void},
@@ -102,9 +110,6 @@ function ParserSettings(on_message_begin_cb::Ptr{Void},
             * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
             * " on_headers_complete_cb, on_body_cb, on_message_complete_cb,"
             * " on_chunk_header, on_chunk_complete)", :ParserSettings)
-    function dummy(parser)
-      0
-    end
     dummy_cb = cfunction(dummy, HTTP_CB...)
     ParserSettings(on_message_begin_cb, on_url_cb, on_status_complete_cb,
       on_header_field_cb, on_header_value_cb, on_headers_complete_cb,
@@ -122,11 +127,8 @@ function ParserSettings(;
   on_message_complete_cb::Ptr{Void} = C_NULL,
   on_chunk_header::Ptr{Void} = C_NULL,
   on_chunk_complete::Ptr{Void} = C_NULL)
-    function dummy(x...)
-      0
-    end
     dummy_cb = cfunction(dummy, HTTP_CB...)
-    dummy_data_cb = cfunction(dummy, HTTP_DATA_CB...)
+    dummy_data_cb = cfunction(dummy_data, HTTP_DATA_CB...)
     ParserSettings(
       on_message_begin_cb == C_NULL ? dummy_cb : on_message_begin_cb,
       on_url_cb == C_NULL ? dummy_data_cb : on_url_cb,

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -88,58 +88,58 @@ type ParserSettings
 end
 
 function dummy(parser)
-  0
+    0
 end
 
 function dummy_data(parser, at, len)
-  0
+    0
 end
 
 function ParserSettings(on_message_begin_cb::Ptr{Void},
-  on_url_cb::Ptr{Void},
-  on_status_complete_cb::Ptr{Void},
-  on_header_field_cb::Ptr{Void},
-  on_header_value_cb::Ptr{Void},
-  on_headers_complete_cb::Ptr{Void},
-  on_body_cb::Ptr{Void},
-  on_message_complete_cb::Ptr{Void})
+    on_url_cb::Ptr{Void},
+    on_status_complete_cb::Ptr{Void},
+    on_header_field_cb::Ptr{Void},
+    on_header_value_cb::Ptr{Void},
+    on_headers_complete_cb::Ptr{Void},
+    on_body_cb::Ptr{Void},
+    on_message_complete_cb::Ptr{Void})
     Base.depwarn("ParserSettings(on_url_cb, on_status_complete_cb, "
-            * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
-            * " on_headers_complete_cb, on_body_cb, on_message_complete_cb)"
-            * " is deprecated use ParserSettings(on_url_cb, on_status_complete_cb, "
-            * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
-            * " on_headers_complete_cb, on_body_cb, on_message_complete_cb,"
-            * " on_chunk_header, on_chunk_complete)", :ParserSettings)
+               * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
+               * " on_headers_complete_cb, on_body_cb, on_message_complete_cb)"
+               * " is deprecated use ParserSettings(on_url_cb, on_status_complete_cb, "
+               * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
+               * " on_headers_complete_cb, on_body_cb, on_message_complete_cb,"
+               * " on_chunk_header, on_chunk_complete)", :ParserSettings)
     dummy_cb = cfunction(dummy, HTTP_CB...)
     ParserSettings(on_message_begin_cb, on_url_cb, on_status_complete_cb,
-      on_header_field_cb, on_header_value_cb, on_headers_complete_cb,
-      on_body_cb, on_message_complete_cb, dummy_cb, dummy_cb)
+        on_header_field_cb, on_header_value_cb, on_headers_complete_cb,
+        on_body_cb, on_message_complete_cb, dummy_cb, dummy_cb)
 end
 
 function ParserSettings(;
-  on_message_begin_cb::Ptr{Void} = C_NULL,
-  on_url_cb::Ptr{Void} = C_NULL,
-  on_status_complete_cb::Ptr{Void} = C_NULL,
-  on_header_field_cb::Ptr{Void} = C_NULL,
-  on_header_value_cb::Ptr{Void} = C_NULL,
-  on_headers_complete_cb::Ptr{Void} = C_NULL,
-  on_body_cb::Ptr{Void} = C_NULL,
-  on_message_complete_cb::Ptr{Void} = C_NULL,
-  on_chunk_header::Ptr{Void} = C_NULL,
-  on_chunk_complete::Ptr{Void} = C_NULL)
+    on_message_begin_cb::Ptr{Void} = C_NULL,
+    on_url_cb::Ptr{Void} = C_NULL,
+    on_status_complete_cb::Ptr{Void} = C_NULL,
+    on_header_field_cb::Ptr{Void} = C_NULL,
+    on_header_value_cb::Ptr{Void} = C_NULL,
+    on_headers_complete_cb::Ptr{Void} = C_NULL,
+    on_body_cb::Ptr{Void} = C_NULL,
+    on_message_complete_cb::Ptr{Void} = C_NULL,
+    on_chunk_header::Ptr{Void} = C_NULL,
+    on_chunk_complete::Ptr{Void} = C_NULL)
     dummy_cb = cfunction(dummy, HTTP_CB...)
     dummy_data_cb = cfunction(dummy_data, HTTP_DATA_CB...)
     ParserSettings(
-      on_message_begin_cb == C_NULL ? dummy_cb : on_message_begin_cb,
-      on_url_cb == C_NULL ? dummy_data_cb : on_url_cb,
-      on_status_complete_cb == C_NULL ? dummy_cb : on_status_complete_cb,
-      on_header_field_cb == C_NULL ? dummy_data_cb : on_header_field_cb,
-      on_header_value_cb == C_NULL ? dummy_data_cb : on_header_value_cb,
-      on_headers_complete_cb == C_NULL ? dummy_cb : on_headers_complete_cb,
-      on_body_cb == C_NULL ? dummy_data_cb : on_body_cb,
-      on_message_complete_cb == C_NULL ? dummy_cb : on_message_complete_cb,
-      on_chunk_header == C_NULL ? dummy_cb : on_chunk_header,
-      on_chunk_complete == C_NULL ? dummy_cb : on_chunk_complete)
+        on_message_begin_cb == C_NULL ? dummy_cb : on_message_begin_cb,
+        on_url_cb == C_NULL ? dummy_data_cb : on_url_cb,
+        on_status_complete_cb == C_NULL ? dummy_cb : on_status_complete_cb,
+        on_header_field_cb == C_NULL ? dummy_data_cb : on_header_field_cb,
+        on_header_value_cb == C_NULL ? dummy_data_cb : on_header_value_cb,
+        on_headers_complete_cb == C_NULL ? dummy_cb : on_headers_complete_cb,
+        on_body_cb == C_NULL ? dummy_data_cb : on_body_cb,
+        on_message_complete_cb == C_NULL ? dummy_cb : on_message_complete_cb,
+        on_chunk_header == C_NULL ? dummy_cb : on_chunk_header,
+        on_chunk_complete == C_NULL ? dummy_cb : on_chunk_complete)
 end
 
 function show(io::IO,p::Parser)

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -102,7 +102,7 @@ function ParserSettings(on_message_begin_cb::Ptr{Void},
             * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
             * " on_headers_complete_cb, on_body_cb, on_message_complete_cb,"
             * " on_chunk_header, on_chunk_complete)", :ParserSettings)
-    dummy_cb = cfunction(() -> 0, HTTP_CB...)
+    dummy_cb = cfunction((parser) -> 0, HTTP_CB...)
     ParserSettings(on_message_begin_cb, on_url_cb, on_status_complete_cb,
       on_header_field_cb, on_header_value_cb, on_headers_complete_cb,
       on_body_cb, on_message_complete_cb, dummy_cb, dummy_cb)

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -87,6 +87,27 @@ type ParserSettings
     on_chunk_complete::Ptr{Void}
 end
 
+function ParserSettings(on_message_begin_cb::Ptr{Void},
+  on_url_cb::Ptr{Void},
+  on_status_complete_cb::Ptr{Void},
+  on_header_field_cb::Ptr{Void},
+  on_header_value_cb::Ptr{Void},
+  on_headers_complete_cb::Ptr{Void},
+  on_body_cb::Ptr{Void},
+  on_message_complete_cb::Ptr{Void})
+    Base.depwarn("ParserSettings(on_url_cb, on_status_complete_cb, "
+            * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
+            * " on_headers_complete_cb, on_body_cb, on_message_complete_cb)"
+            * " is deprecated use ParserSettings(on_url_cb, on_status_complete_cb, "
+            * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
+            * " on_headers_complete_cb, on_body_cb, on_message_complete_cb,"
+            * " on_chunk_header, on_chunk_complete)", :ParserSettings)
+    dummy_cb = cfunction(() -> 0, HTTP_CB...)
+    ParserSettings(on_message_begin_cb, on_url_cb, on_status_complete_cb,
+      on_header_field_cb, on_header_value_cb, on_headers_complete_cb,
+      on_body_cb, on_message_complete_cb, dummy_cb, dummy_cb)
+end
+
 function show(io::IO,p::Parser)
     print(io,"libhttp-parser: v$(version()), ")
     print(io,"HTTP/$(p.http_major).$(p.http_minor), ")

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -87,31 +87,31 @@ type ParserSettings
     on_chunk_complete::Ptr{Void}
 
     function ParserSettings(
-      on_message_begin_cb::Ptr{Void} = Ptr{Void}(0),
-      on_url_cb::Ptr{Void} = Ptr{Void}(0),
-      on_status_complete_cb::Ptr{Void} = Ptr{Void}(0),
-      on_header_field_cb::Ptr{Void} = Ptr{Void}(0),
-      on_header_value_cb::Ptr{Void} = Ptr{Void}(0),
-      on_headers_complete_cb::Ptr{Void} = Ptr{Void}(0),
-      on_body_cb::Ptr{Void} = Ptr{Void}(0),
-      on_message_complete_cb::Ptr{Void} = Ptr{Void}(0),
-      on_chunk_header::Ptr{Void} = Ptr{Void}(0),
-      on_chunk_complete::Ptr{Void} = Ptr{Void}(0))
+      on_message_begin_cb::Ptr{Void} = C_NULL,
+      on_url_cb::Ptr{Void} = C_NULL,
+      on_status_complete_cb::Ptr{Void} = C_NULL,
+      on_header_field_cb::Ptr{Void} = C_NULL,
+      on_header_value_cb::Ptr{Void} = C_NULL,
+      on_headers_complete_cb::Ptr{Void} = C_NULL,
+      on_body_cb::Ptr{Void} = C_NULL,
+      on_message_complete_cb::Ptr{Void} = C_NULL,
+      on_chunk_header::Ptr{Void} = C_NULL,
+      on_chunk_complete::Ptr{Void} = C_NULL)
         function dummy(parser)
           0
         end
         dummy_cb = cfunction(dummy, HTTP_CB...)
         new(
-          on_message_begin_cb == Ptr{Void}(0) ? dummy_cb : on_message_begin_cb,
-          on_url_cb == Ptr{Void}(0) ? dummy_cb : on_url_cb,
-          on_status_complete_cb == Ptr{Void}(0) ? dummy_cb : on_status_complete_cb,
-          on_header_field_cb == Ptr{Void}(0) ? dummy_cb : on_header_field_cb,
-          on_header_value_cb == Ptr{Void}(0) ? dummy_cb : on_header_value_cb,
-          on_headers_complete_cb == Ptr{Void}(0) ? dummy_cb : on_headers_complete_cb,
-          on_body_cb == Ptr{Void}(0) ? dummy_cb : on_body_cb,
-          on_message_complete_cb == Ptr{Void}(0) ? dummy_cb : on_message_complete_cb,
-          on_chunk_header == Ptr{Void}(0) ? dummy_cb : on_chunk_header,
-          on_chunk_complete == Ptr{Void}(0) ? dummy_cb : on_chunk_complete)
+          on_message_begin_cb == C_NULL ? dummy_cb : on_message_begin_cb,
+          on_url_cb == C_NULL ? dummy_cb : on_url_cb,
+          on_status_complete_cb == C_NULL ? dummy_cb : on_status_complete_cb,
+          on_header_field_cb == C_NULL ? dummy_cb : on_header_field_cb,
+          on_header_value_cb == C_NULL ? dummy_cb : on_header_value_cb,
+          on_headers_complete_cb == C_NULL ? dummy_cb : on_headers_complete_cb,
+          on_body_cb == C_NULL ? dummy_cb : on_body_cb,
+          on_message_complete_cb == C_NULL ? dummy_cb : on_message_complete_cb,
+          on_chunk_header == C_NULL ? dummy_cb : on_chunk_header,
+          on_chunk_complete == C_NULL ? dummy_cb : on_chunk_complete)
     end
 end
 

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -85,34 +85,59 @@ type ParserSettings
     on_message_complete_cb::Ptr{Void}
     on_chunk_header::Ptr{Void}
     on_chunk_complete::Ptr{Void}
+end
 
-    function ParserSettings(
-      on_message_begin_cb::Ptr{Void} = C_NULL,
-      on_url_cb::Ptr{Void} = C_NULL,
-      on_status_complete_cb::Ptr{Void} = C_NULL,
-      on_header_field_cb::Ptr{Void} = C_NULL,
-      on_header_value_cb::Ptr{Void} = C_NULL,
-      on_headers_complete_cb::Ptr{Void} = C_NULL,
-      on_body_cb::Ptr{Void} = C_NULL,
-      on_message_complete_cb::Ptr{Void} = C_NULL,
-      on_chunk_header::Ptr{Void} = C_NULL,
-      on_chunk_complete::Ptr{Void} = C_NULL)
-        function dummy(parser)
-          0
-        end
-        dummy_cb = cfunction(dummy, HTTP_CB...)
-        new(
-          on_message_begin_cb == C_NULL ? dummy_cb : on_message_begin_cb,
-          on_url_cb == C_NULL ? dummy_cb : on_url_cb,
-          on_status_complete_cb == C_NULL ? dummy_cb : on_status_complete_cb,
-          on_header_field_cb == C_NULL ? dummy_cb : on_header_field_cb,
-          on_header_value_cb == C_NULL ? dummy_cb : on_header_value_cb,
-          on_headers_complete_cb == C_NULL ? dummy_cb : on_headers_complete_cb,
-          on_body_cb == C_NULL ? dummy_cb : on_body_cb,
-          on_message_complete_cb == C_NULL ? dummy_cb : on_message_complete_cb,
-          on_chunk_header == C_NULL ? dummy_cb : on_chunk_header,
-          on_chunk_complete == C_NULL ? dummy_cb : on_chunk_complete)
+function ParserSettings(on_message_begin_cb::Ptr{Void},
+  on_url_cb::Ptr{Void},
+  on_status_complete_cb::Ptr{Void},
+  on_header_field_cb::Ptr{Void},
+  on_header_value_cb::Ptr{Void},
+  on_headers_complete_cb::Ptr{Void},
+  on_body_cb::Ptr{Void},
+  on_message_complete_cb::Ptr{Void})
+    Base.depwarn("ParserSettings(on_url_cb, on_status_complete_cb, "
+            * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
+            * " on_headers_complete_cb, on_body_cb, on_message_complete_cb)"
+            * " is deprecated use ParserSettings(on_url_cb, on_status_complete_cb, "
+            * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
+            * " on_headers_complete_cb, on_body_cb, on_message_complete_cb,"
+            * " on_chunk_header, on_chunk_complete)", :ParserSettings)
+    function dummy(parser)
+      0
     end
+    dummy_cb = cfunction(dummy, HTTP_CB...)
+    ParserSettings(on_message_begin_cb, on_url_cb, on_status_complete_cb,
+      on_header_field_cb, on_header_value_cb, on_headers_complete_cb,
+      on_body_cb, on_message_complete_cb, dummy_cb, dummy_cb)
+end
+
+function ParserSettings(;
+  on_message_begin_cb::Ptr{Void} = C_NULL,
+  on_url_cb::Ptr{Void} = C_NULL,
+  on_status_complete_cb::Ptr{Void} = C_NULL,
+  on_header_field_cb::Ptr{Void} = C_NULL,
+  on_header_value_cb::Ptr{Void} = C_NULL,
+  on_headers_complete_cb::Ptr{Void} = C_NULL,
+  on_body_cb::Ptr{Void} = C_NULL,
+  on_message_complete_cb::Ptr{Void} = C_NULL,
+  on_chunk_header::Ptr{Void} = C_NULL,
+  on_chunk_complete::Ptr{Void} = C_NULL)
+    function dummy(x...)
+      0
+    end
+    dummy_cb = cfunction(dummy, HTTP_CB...)
+    dummy_data_cb = cfunction(dummy, HTTP_DATA_CB...)
+    ParserSettings(
+      on_message_begin_cb == C_NULL ? dummy_cb : on_message_begin_cb,
+      on_url_cb == C_NULL ? dummy_data_cb : on_url_cb,
+      on_status_complete_cb == C_NULL ? dummy_cb : on_status_complete_cb,
+      on_header_field_cb == C_NULL ? dummy_data_cb : on_header_field_cb,
+      on_header_value_cb == C_NULL ? dummy_data_cb : on_header_value_cb,
+      on_headers_complete_cb == C_NULL ? dummy_cb : on_headers_complete_cb,
+      on_body_cb == C_NULL ? dummy_data_cb : on_body_cb,
+      on_message_complete_cb == C_NULL ? dummy_cb : on_message_complete_cb,
+      on_chunk_header == C_NULL ? dummy_cb : on_chunk_header,
+      on_chunk_complete == C_NULL ? dummy_cb : on_chunk_complete)
 end
 
 function show(io::IO,p::Parser)

--- a/src/HttpParser.jl
+++ b/src/HttpParser.jl
@@ -85,27 +85,34 @@ type ParserSettings
     on_message_complete_cb::Ptr{Void}
     on_chunk_header::Ptr{Void}
     on_chunk_complete::Ptr{Void}
-end
 
-function ParserSettings(on_message_begin_cb::Ptr{Void},
-  on_url_cb::Ptr{Void},
-  on_status_complete_cb::Ptr{Void},
-  on_header_field_cb::Ptr{Void},
-  on_header_value_cb::Ptr{Void},
-  on_headers_complete_cb::Ptr{Void},
-  on_body_cb::Ptr{Void},
-  on_message_complete_cb::Ptr{Void})
-    Base.depwarn("ParserSettings(on_url_cb, on_status_complete_cb, "
-            * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
-            * " on_headers_complete_cb, on_body_cb, on_message_complete_cb)"
-            * " is deprecated use ParserSettings(on_url_cb, on_status_complete_cb, "
-            * " on_header_field_cb, on_header_value_cb, on_header_value_cb,"
-            * " on_headers_complete_cb, on_body_cb, on_message_complete_cb,"
-            * " on_chunk_header, on_chunk_complete)", :ParserSettings)
-    dummy_cb = cfunction((parser) -> 0, HTTP_CB...)
-    ParserSettings(on_message_begin_cb, on_url_cb, on_status_complete_cb,
-      on_header_field_cb, on_header_value_cb, on_headers_complete_cb,
-      on_body_cb, on_message_complete_cb, dummy_cb, dummy_cb)
+    function ParserSettings(
+      on_message_begin_cb::Ptr{Void} = Ptr{Void}(0),
+      on_url_cb::Ptr{Void} = Ptr{Void}(0),
+      on_status_complete_cb::Ptr{Void} = Ptr{Void}(0),
+      on_header_field_cb::Ptr{Void} = Ptr{Void}(0),
+      on_header_value_cb::Ptr{Void} = Ptr{Void}(0),
+      on_headers_complete_cb::Ptr{Void} = Ptr{Void}(0),
+      on_body_cb::Ptr{Void} = Ptr{Void}(0),
+      on_message_complete_cb::Ptr{Void} = Ptr{Void}(0),
+      on_chunk_header::Ptr{Void} = Ptr{Void}(0),
+      on_chunk_complete::Ptr{Void} = Ptr{Void}(0))
+        function dummy(parser)
+          0
+        end
+        dummy_cb = cfunction(dummy, HTTP_CB...)
+        new(
+          on_message_begin_cb == Ptr{Void}(0) ? dummy_cb : on_message_begin_cb,
+          on_url_cb == Ptr{Void}(0) ? dummy_cb : on_url_cb,
+          on_status_complete_cb == Ptr{Void}(0) ? dummy_cb : on_status_complete_cb,
+          on_header_field_cb == Ptr{Void}(0) ? dummy_cb : on_header_field_cb,
+          on_header_value_cb == Ptr{Void}(0) ? dummy_cb : on_header_value_cb,
+          on_headers_complete_cb == Ptr{Void}(0) ? dummy_cb : on_headers_complete_cb,
+          on_body_cb == Ptr{Void}(0) ? dummy_cb : on_body_cb,
+          on_message_complete_cb == Ptr{Void}(0) ? dummy_cb : on_message_complete_cb,
+          on_chunk_header == Ptr{Void}(0) ? dummy_cb : on_chunk_header,
+          on_chunk_complete == Ptr{Void}(0) ? dummy_cb : on_chunk_complete)
+    end
 end
 
 function show(io::IO,p::Parser)


### PR DESCRIPTION
Currently a lot of packages that rely on the HttpParser fail to build because of the backward incompatible changes in the signature of the ParserSettings constructor. I've added an additional constructor to ParserSettings with the old signature that prints a deprecated warning, but gives all packages that rely on HttpParser a grace period to update.
