### PR TITLE
Make HttpParser validate binaries

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,7 @@ using Compat
 
 @BinDeps.setup
 
-version=v"2.6.2"
+version=v"2.7.1"
 
 aliases = []
 if is_windows()
@@ -14,7 +14,17 @@ if is_windows()
     end
 end
 
-libhttp_parser = library_dependency("libhttp_parser", aliases=aliases)
+function validate_httpparser(name,handle)
+    try
+        p = Libdl.dlsym(handle, :http_parser_url_init)
+        return p != C_NULL
+    catch
+        return false
+    end
+end
+
+libhttp_parser = library_dependency("libhttp_parser", aliases=aliases,
+                                     validate=validate_httpparser)
 
 if is_unix()
     src_arch = "v$version.zip"
@@ -49,7 +59,7 @@ end
 # Windows
 if is_windows()
     provides(Binaries,
-         URI("https://julialang.s3.amazonaws.com/bin/winnt/extras/libhttp_parser.zip"),
+         URI("https://s3.amazonaws.com/julialang/bin/winnt/extras/libhttp_parser_2_7_1.zip"),
          libhttp_parser, os = :Windows)
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -20,7 +20,9 @@ function validate_httpparser(name,handle)
         p = Libdl.dlsym(handle, :http_parser_url_init)
         return p != C_NULL
     catch
-        warn("Looks like your binary is old. Please run `rm($(sprint(show, joinpath(dirname(@__FILE__), "usr"))); recursive = true)` to delete the old binary and then run `Pkg.build($(sprint(show, "HttpParser")))` again.")
+        if is_windows()
+            warn("Looks like your binary is old. Please run `rm($(sprint(show, joinpath(dirname(@__FILE__), "usr"))); recursive = true)` to delete the old binary and then run `Pkg.build($(sprint(show, "HttpParser")))` again.")
+        end
         return false
     end
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -19,7 +19,7 @@ function validate_httpparser(name,handle)
         p = Libdl.dlsym(handle, :http_parser_url_init)
         return p != C_NULL
     catch
-        warn("Looks like your binary is old. Please run `rm(\"$(joinpath(dirname(@__FILE__), "usr"))\"; recursive = true)` to delete the old binary and then run `Pkg.build(\"HttpParser\")` again.")
+        warn("Looks like your binary is old. Please run `rm($(sprint(show, joinpath(dirname(@__FILE__), "usr"))); recursive = true)` to delete the old binary and then run `Pkg.build($(sprint(show, "HttpParser")))` again.")
         return false
     end
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -59,6 +59,7 @@ end
 
 # Windows
 if is_windows()
+    rm(joinpath(dirname(@__FILE__), "usr"); force = true, recursive = true)
     provides(Binaries,
          URI("https://s3.amazonaws.com/julialang/bin/winnt/extras/libhttp_parser_2_7_1.zip"),
          libhttp_parser, os = :Windows)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -45,6 +45,7 @@ if is_unix()
                 CreateDirectory(BinDeps.libdir(libhttp_parser))
                 @build_steps begin
                     ChangeDirectory(targetsrcdir)
+                    `rm -f $src_dir/$target $targetlib`
                     FileRule(targetlib, @build_steps begin
                         ChangeDirectory(BinDeps.srcdir(libhttp_parser))
                         CreateDirectory(dirname(targetlib))

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -19,6 +19,7 @@ function validate_httpparser(name,handle)
         p = Libdl.dlsym(handle, :http_parser_url_init)
         return p != C_NULL
     catch
+        warn("Looks like your binary is old. Please run `rm(\"$(joinpath(dirname(@__FILE__), "usr"))\"; recursive = true)` to delete the old binary and then run `Pkg.build(\"HttpParser\")` again.")
         return false
     end
 end
@@ -59,7 +60,6 @@ end
 
 # Windows
 if is_windows()
-    rm(joinpath(dirname(@__FILE__), "usr"); force = true, recursive = true)
     provides(Binaries,
          URI("https://s3.amazonaws.com/julialang/bin/winnt/extras/libhttp_parser_2_7_1.zip"),
          libhttp_parser, os = :Windows)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,6 +14,7 @@ if is_windows()
     end
 end
 
+# This API used for validation was introduced in 2.6.0, and there have no API changes between 2.6 and 2.7
 function validate_httpparser(name,handle)
     try
         p = Libdl.dlsym(handle, :http_parser_url_init)


### PR DESCRIPTION
This PR:
* Adds validation check for binary, 
* Changes windows URL to the new cross-compiled binary
* Bumps new binary version to be downloaded for Unix