### PR TITLE
Add Homebrew installation method for compileless OSX installation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4
 HttpCommon
 BinDeps
 Compat 0.7.20
+@osx Homebrew

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -30,6 +30,11 @@ end
 libhttp_parser = library_dependency("libhttp_parser", aliases=aliases,
                                      validate=validate_httpparser)
 
+if is_apple()
+    using Homebrew
+    provides( Homebrew.HB, "http-parser", libhttp_parser, os = :Darwin )
+end
+
 if is_unix()
     src_arch = "v$version.zip"
     src_url = "https://github.com/nodejs/http-parser/archive/$src_arch"


### PR DESCRIPTION
Without this, I get compiler errors while trying to build `libhttp_parser`, because it tries to pass an SONAME linker option:

```
...
INFO: Changing Directory to /Users/sabae/.julia/v0.4/HttpParser/deps/src
cc  -shared -Wl,-soname=libhttp_parser.dylib -o libhttp_parser.dylib libhttp_parser.o
ld: unknown option: -soname=libhttp_parser.dylib
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [library] Error 1
```

With this, we never need to invoke a compiler.  Yay!
