### PR TITLE
Adding the deps/src directory to gitignore

### DIFF
--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,3 +1,7 @@
+*.jl.cov
+*.jl.*.cov
+*.jl.mem
+
 deps.jl
 downloads/*
 usr/*

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,3 +1,4 @@
 deps.jl
 downloads/*
 usr/*
+src/*


### PR DESCRIPTION
Not including the `/deps/src` directory in `gitignore` makes the local copy have untracked files after the build process.  This causes problems with packaging systems e.g. DeclarativePackages.jl