### PR TITLE
Updated deps to HttpParser v2.8.0

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,7 @@ using Compat
 
 @BinDeps.setup
 
-version=v"2.7.1"
+version=v"2.8.0"
 
 aliases = []
 if is_windows()


### PR DESCRIPTION
https://github.com/nodejs/http-parser/releases
Updated with HttpParser v2.8.0 for Unix. Windows dependency takes an aws link, host the updated package there and replace the link on line: 67.