### PR TITLE
`patch --verbose` make FreeBSD unhappy

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -42,7 +42,7 @@ if is_unix()
     patchfile = joinpath(BinDeps.depsdir(libhttp_parser), "patches", "pull-357.patch")
     if version == v"2.7.1" && !isfile(joinpath(targetsrcdir, "http_parser.c.orig"))
         PatchStep = (@build_steps begin
-            pipeline(`cat $patchfile`, `patch --verbose -b -p1 -d $targetsrcdir`)
+            pipeline(`cat $patchfile`, `patch -b -p1 -d $targetsrcdir`)
         end)
     else
         PatchStep = (@build_steps begin end)


### PR DESCRIPTION
on FreeBSD:
```
(v0.7) pkg> build HttpParser
  Building HttpParser → `~/.julia/packages/HttpParser/yGK3a/deps/build.log`
┌ Error: Error building `HttpParser`:
│ patch: unrecognized option `--verbose'
│ usage: patch [-bCcEeflNnRstuv] [-B backup-prefix] [-D symbol] [-d directory]
│              [-F max-fuzz] [-i patchfile] [-o out-file] [-p strip-count]
│              [-r rej-name] [-V t | nil | never | none] [-x number]
│              [-z backup-ext] [--posix] [origfile [patchfile]]
│        patch <patchfile
```